### PR TITLE
Adds non-zero exit codes for the case where requests fail

### DIFF
--- a/api/create_release.sh
+++ b/api/create_release.sh
@@ -48,7 +48,7 @@ create_release() {
   release=$(<"$response_body")
   rm -f "$response_body"
 
-  makeFullResponse "$upload_info" "$http_code"
+  makeFullResponse "$http_code" "$upload_info"
 }
 
 #######################################
@@ -61,7 +61,7 @@ create_release() {
 #   Returns upload http status and response body from the upload request.
 process_create_release_response() {
   local http_status=$(getHttpStatusFromFullResponse "$1")
-  printf "upload http status: %s" "$http_status"
+  printf "upload http status: %s\n" "$http_status"
 
   local body=$(getBodyFromFullResponse "$1")
   if [[ -n "$body" ]]; then

--- a/api/create_release.sh
+++ b/api/create_release.sh
@@ -42,9 +42,13 @@ check_dependencies() {
 #   Returns the created release.
 #######################################
 create_release() {
-  release=$(curl -s -H "Authorization: $AUTHORIZATION_TOKEN" -H "Content-Type: application/json" -X "POST" "$RM_API_HOST/release-management/v1/releases" -d "{\"connected_app_id\": \"$CONNECTED_APP_ID\", \"name\": \"$RELEASE_NAME\"}")
+  
+  response_body=$(mktemp)
+  http_code=$(curl -s -w "%{http_code}" -H "Authorization: $AUTHORIZATION_TOKEN" -H "Content-Type: application/json" -X "POST" -o "$response_body" "$RM_API_HOST/release-management/v1/releases" -d "{\"connected_app_id\": \"$CONNECTED_APP_ID\", \"name\": \"$RELEASE_NAME\"}")
+  release=$(<"$response_body")
+  rm -f "$response_body"
 
-  echo "$release"
+  makeFullResponse "$upload_info" "$http_code"
 }
 
 #######################################
@@ -56,8 +60,14 @@ create_release() {
 # Outputs:
 #   Returns upload http status and response body from the upload request.
 process_create_release_response() {
-  printf "upload http status: %s\n" "${1:${#1}-3}"
-  echo "${1}" | jq .
+  local http_status=$(getHttpStatusFromFullResponse "$1")
+  printf "upload http status: %s" "$http_status"
+
+  local body=$(getBodyFromFullResponse "$1")
+  if [[ -n "$body" ]]; then
+    echo "${body}" | jq .
+  fi
+  
 }
 
 check_dependencies
@@ -66,6 +76,6 @@ if [ -z "$RM_API_HOST" ]; then
   RM_API_HOST="https://api.bitrise.io"
 fi
 
-release=$(create_release)
-request_error "$release"
-process_create_release_response "$release"
+release_full_resp=$(create_release)
+request_error "$release_full_resp" '/releases'
+process_create_release_response  "$release_full_resp"

--- a/api/upload_installable_artifact.sh
+++ b/api/upload_installable_artifact.sh
@@ -91,7 +91,7 @@ is_processed() {
   rm -f "$response_body"
 
   fullResponse=$(makeFullResponse "$status_data" "$http_code")
-  request_error "$fullResponse"
+  request_error "$fullResponse" "installable-artifacts/$1/status"
 
   status=$(echo "$status_data" | jq -r '.status')
   if [[ "$status" == "processed_valid" ]] || [[ "$status" == "processed_invalid" ]]; then

--- a/api/upload_installable_artifact.sh
+++ b/api/upload_installable_artifact.sh
@@ -63,7 +63,7 @@ get_upload_information() {
   upload_info=$(<"$response_body")
   rm -f "$response_body"
 
-  makeFullResponse "$upload_info" "$http_code"
+  makeFullResponse "$http_code" "$upload_info"
 }
 
 #######################################
@@ -90,8 +90,8 @@ is_processed() {
   status_data=$(<"$response_body")
   rm -f "$response_body"
 
-  fullResponse=$(makeFullResponse "$status_data" "$http_code")
-  request_error "$fullResponse" "installable-artifacts/$1/status"
+  fullResponse=$(makeFullResponse "$http_code" "$status_data")
+  request_error "$fullResponse" "/installable-artifacts/$1/status"
 
   status=$(echo "$status_data" | jq -r '.status')
   if [[ "$status" == "processed_valid" ]] || [[ "$status" == "processed_invalid" ]]; then
@@ -175,7 +175,7 @@ if [ -z "$RM_API_HOST" ]; then
 fi
 
 upload_info_full_resp=$(get_upload_information "$installable_artifact_id")
-request_error "$upload_info_full_resp" 'installable-artifacts/$1/upload-url'
+request_error "$upload_info_full_resp" '/installable-artifacts/$1/upload-url'
 upload_info=$(getBodyFromFullResponse "$upload_info_full_resp")
 upload_response=$(upload_artifact "$upload_info")
 process_upload_response "$upload_response" "$installable_artifact_id"

--- a/api/utility/request_handler.sh
+++ b/api/utility/request_handler.sh
@@ -44,7 +44,7 @@ request_error() {
 #   A JSON object with the response body
 getBodyFromFullResponse() {
   local full_response=$1
-  echo "$full_response" | jq ".response_body"
+  echo "$full_response" | jq ".response_body  // empty"
 }
 
 #######################################
@@ -73,6 +73,11 @@ makeFullResponse() {
   local body=$1
   local http_code=$2
 
-  jq -n --argjson body "$body" --argjson http_code "$http_code" \
-    '{"http_code": $http_code, "response_body": $body}'
+  if [[ -z "$body" ]]; then
+    jq -n --argjson http_code "$http_code" \
+      '{"http_code": $http_code}'
+  else
+    jq -n --argjson body "$body" --argjson http_code "$http_code" \
+      '{"http_code": $http_code, "response_body": $body}'
+  fi
 }

--- a/api/utility/request_handler.sh
+++ b/api/utility/request_handler.sh
@@ -65,13 +65,13 @@ getHttpStatusFromFullResponse() {
 # Globals:
 #   None
 # Arguments:
-#   The response body.
 #   The http code (int)
+#   The response body (string in json format) - optional
 # Outputs:
 #   A JSON object with format {"http_code": <int>, "response_body": <string>}
 makeFullResponse() {
-  local body=$1
-  local http_code=$2
+  local http_code=$1
+  local body=$2
 
   if [[ -z "$body" ]]; then
     jq -n --argjson http_code "$http_code" \

--- a/api/utility/request_handler.sh
+++ b/api/utility/request_handler.sh
@@ -7,16 +7,72 @@
 # Globals:
 #   None
 # Arguments:
-#   The response body.
+#   A JSON object with keys `response_body` and `http_code` (created by makeFullResponse())
 # Outputs:
 #   Returns the error if there is an error.
 request_error() {
-  error_code=$(echo "$1" | jq '.code' )
-  if [ "$error_code" == "null" ]; then
-    return
+  local body=$(getBodyFromFullResponse "$1")
+  local http_code=$(getHttpStatusFromFullResponse "$1")
+
+  local endpointName="$2"
+  local non200=0
+  local hasResponseErr=0
+
+  if [[ $http_code -lt 200 || $http_code -ge 300 ]]; then
+    non200=1
+    echo "Error: ${endpointName} request failed with status $http_code" >&2
+  fi
+  
+  error_code=$(echo "$body" | jq '.code' )
+  if [[ -n "$error_code" && "$error_code" != "null" ]]; then
+    hasResponseErr=1
+    echo "$body" | jq .
   fi
 
-  echo "$1" | jq .
+  if [[ $hasResponseErr -eq 1 || $non200 -eq 1 ]]; then
+    exit 1
+  fi
+}
 
-  exit 0
+#######################################
+# Gets response body from makeFullResponse() json object
+# Globals:
+#   None
+# Arguments:
+#   A JSON object with keys `response_body` and `http_code` (created by makeFullResponse())
+# Outputs:
+#   A JSON object with the response body
+getBodyFromFullResponse() {
+  local full_response=$1
+  echo "$full_response" | jq ".response_body"
+}
+
+#######################################
+# Gets response body from makeFullResponse() json object
+# Globals:
+#   None
+# Arguments:
+#   A JSON object with keys `response_body` and `http_code` (created by makeFullResponse())
+# Outputs:
+#   A string with the http status code of the response
+getHttpStatusFromFullResponse() {
+  local full_response=$1
+  echo "$full_response" | jq ".http_code"
+}
+
+#######################################
+# Combines the HTTP response code and response body into a json object
+# Globals:
+#   None
+# Arguments:
+#   The response body.
+#   The http code (int)
+# Outputs:
+#   A JSON object with format {"http_code": <int>, "response_body": <string>}
+makeFullResponse() {
+  local body=$1
+  local http_code=$2
+
+  jq -n --argjson body "$body" --argjson http_code "$http_code" \
+    '{"http_code": $http_code, "response_body": $body}'
 }


### PR DESCRIPTION
For customers that add this script to their non-Bitrise CI pipelines, if the script fails, it should exit with a non-zero exit code so that their pipeline will fail. This will ensure they are aware the artifact failed to upload, preventing testers from potentially testing the wrong version.